### PR TITLE
Allow shortcuts for encounter names

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,12 @@ if __name__ == '__main__':
             with open(my_file, 'w') as f:
                 f.write(str(input_index))
 
-    encounter = input("Choose your encounter file (templar/atheon): ")
+    encounter = input("Choose your encounter file ((t)emplar/(a)theon): ").lower()
+
+    if encounter == 't':
+        encounter = 'templar'
+    elif encounter == 'a':
+        encounter = 'atheon'
 
     with open(resource_path(encounter + '.json')) as f:
         oracle_map = json.load(f)

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
             with open(my_file, 'w') as f:
                 f.write(str(input_index))
 
-    encounter = input("Choose your encounter file ((t)emplar/(a)theon): ").lower()
+    encounter = input("Choose your encounter file ([t]emplar/[a]theon): ").lower()
 
     if encounter == 't':
         encounter = 'templar'


### PR DESCRIPTION
Using this with my clan (We LOVE it btw!). Someone had a suggestion to make the encounter commands easier to type quickly.

- Added shortcuts for the encounter. t == templar, a == atheon
- Made encounter name input case insensitive